### PR TITLE
Linking in test cases for linux

### DIFF
--- a/Tests/PerfectRedisTests/PerfectRedisTests.swift
+++ b/Tests/PerfectRedisTests/PerfectRedisTests.swift
@@ -480,7 +480,16 @@ class PerfectRedisTests: XCTestCase {
     
     static var allTests : [(String, (PerfectRedisTests) -> () throws -> Void)] {
         return [
-            ("testPing", testPing)
+            ("testPing", testPing),
+            ("testPubSub", testPubSub),
+            ("testGetClient", testGetClient),
+            ("testFlushAll", testFlushAll),
+            ("testAppend", testAppend),
+            ("testSetGet", testSetGet),
+            ("testExists", testExists),
+            ("testSetGetXX", testSetGetXX),
+            ("testSetGetNX", testSetGetNX),
+            ("testSetGetExp", testSetGetExp)
         ]
     }
 }


### PR DESCRIPTION
Not all tests were linked in, so `swift test` was only running `testPing` (at least on linux)