### PR TITLE
update package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ RedisClient.getClient(withIdentifier: RedisClientIdentifier()) {
 Add this project as a dependency in your Package.swift file.
 
 ```
-.Package(url: "https://github.com/PerfectlySoft/Perfect-Redis.git", Version(0,0,0)..<Version(10,0,0))
+.Package(url: "https://github.com/PerfectlySoft/Perfect-Redis.git", majorVersion: 2, minor: 0)
 ```
 
 


### PR DESCRIPTION
Version ranges "Version(0,0,0)..<Version(10,0,0)" were generating exceptions when building:

Package.swift:28:85: error: no '..<' candidates produce the expected contextual result type 'Version'

Package.swift:28:85: note: overloads for '..<' exist with these result types: Range<Bound>, CountableRange<Bound>