### PR TITLE
- Added "public" modifier to RedisValue and sendCommand to work aroun…

### DIFF
--- a/Sources/PerfectRedis.swift
+++ b/Sources/PerfectRedis.swift
@@ -235,7 +235,7 @@ public class RedisClient {
         case string(String)
         case binary([UInt8])
 
-        func toString() -> String {
+        public func toString() -> String {
             switch self {
             case .string(let s): return "\"\(s)\""
             case .binary(let b) : return "\"\(hexString(fromArray: b))\""
@@ -283,8 +283,8 @@ public class RedisClient {
     var availableBufferedBytes: Int {
         return self.readBuffer.count - self.readBufferOffset
     }
-
-    init(net: NetTCP) {
+    
+    public init(net: NetTCP) {
         self.net = net
     }
 
@@ -314,12 +314,12 @@ public class RedisClient {
         return self.appendCRLF(to: name.bytes)
     }
 
-    func sendCommand(name: String, parameters: [RedisResponse], callback: @escaping redisResponseCallback) {
+    public func sendCommand(name: String, parameters: [RedisResponse], callback: @escaping redisResponseCallback) {
         let a = self.commandBytes(name: name, parameters: parameters)
         self.sendRawCommand(bytes: a, callback: callback)
     }
 
-    func sendCommand(name: String, callback: @escaping redisResponseCallback) {
+    public func sendCommand(name: String, callback: @escaping redisResponseCallback) {
         let a = self.commandBytes(name: name)
         self.sendRawCommand(bytes: a, callback: callback)
     }


### PR DESCRIPTION
Issue encountered:

When transmitting json strings to redis (via LPUSH/LPUSHX) after using jsonEncodedString(), the values were being rejected.  The situation was remedied by encoding the string with a leading and trailing single quote character instead of double quotes.  To accomplish this, I needed extensions[1].  However, toString() in RedisValue and the sendCommand used within listPrepend and listPrependX were subject to "internal protection level" compilation errors.

Proposed solution:  Add "public" to sendCommand() and toString() so downstream users can make tweaks in edge cases such as mine.

[1] Example extensions (mild tweaks on top of existing implementations):

extension RedisClient.RedisValue {
    func toStringForRedis() -> String {
        switch self {
            case .string(let s): return "'\(s)'"
            default:
                return self.toString()
        }
    }
}

extension RedisClient {
    func listPrepend(key: String, jsonRedisValues: [RedisValue], callback: @escaping redisResponseCallback) {
        self.sendCommand(name: "LPUSH \(key) \(jsonRedisValues.map { $0.toStringForRedis() }.joined(separator: " "))", callback: callback)
    }
}
