### PR TITLE
Add sendCommandAsRESP func

### DIFF
--- a/Sources/PerfectRedis.swift
+++ b/Sources/PerfectRedis.swift
@@ -323,6 +323,15 @@ public class RedisClient {
         let a = self.commandBytes(name: name)
         self.sendRawCommand(bytes: a, callback: callback)
     }
+    
+    // Send command as serialized in RESP format: See https://redis.io/topics/protocol
+    public func sendCommandAsRESP(name: String, parameters: [String], callback: @escaping redisResponseCallback) {
+    
+        var array = [RedisResponse.bulkString(name.bytes)]
+        array.append(contentsOf: parameters.flatMap({ RedisResponse.bulkString($0.bytes) }))
+        
+        self.sendRawCommand(bytes: RedisResponse.array(array).toBytes(), callback: callback)
+    }
 
     // sends the bytes to trhe client
     // reads response when the bytes have been sent


### PR DESCRIPTION
The library currently sends commands in the 'inline' format rather than using the REdis Serialization Protocol (see [docs](https://redis.io/topics/protocol) ). The 'inline' approach has a much smaller limit than RESP in terms of the size of the data that can be sent in for example a SET command.

By adding `public func sendCommandAsRESP` these limits can be avoided when necessary.

Perhaps in time the library can be refactored internally to use `sendCommandAsRESP` throughout, but I don't currently have time to do this.
